### PR TITLE
Addresses the duplicate key error raised when using linked files 

### DIFF
--- a/src/RunCoverletReport/CoverageResults/Models/ClassResult.cs
+++ b/src/RunCoverletReport/CoverageResults/Models/ClassResult.cs
@@ -1,6 +1,7 @@
 ﻿namespace RunCoverletReport.CoverageResults.Models
 {
     using System.Collections.Generic;
+    using System.Diagnostics;
 
     /// <summary>
     /// Defines the <see cref="ClassResult" />.
@@ -45,6 +46,47 @@
         {
             foreach (var result in lineResults)
             {
+                if (LineResults.ContainsKey(result.Value.LineNumber))
+                {
+                    //take the most optimistic coverage record.
+                    var takeNewResult = false;
+                    var existingResult = LineResults[result.Value.LineNumber];
+                    var newResult = result.Value;
+
+                    //some coverage better than none
+                    if ((newResult.Result == LineResult.CoverageResultType.Covered || newResult.Result == LineResult.CoverageResultType.PartCovered)
+                        && existingResult.Result == LineResult.CoverageResultType.UnCovered)
+                    {
+                        takeNewResult = true;
+                    }
+                    
+                    //more coverage better than some
+                    if ((newResult.Result == LineResult.CoverageResultType.Covered)
+                        && existingResult.Result == LineResult.CoverageResultType.PartCovered)
+                    {
+                        takeNewResult = true;
+                    }
+
+                    //more hits better than less hits
+                    if (newResult.Hits > existingResult.Hits)
+                    {
+                        takeNewResult = true;
+                    }
+
+                    if (takeNewResult)
+                    {
+                        Trace.TraceInformation($"{nameof(RunCoverletReport)} - {nameof(LineResult)} previously recorded in this session " +
+                            $"for '{FileName}':{result.Value.LineNumber} will be discarded: {existingResult}");
+                        LineResults[newResult.LineNumber] = newResult;
+                    }
+                    else
+                    {
+                        Trace.TraceError($"{nameof(RunCoverletReport)} - {nameof(LineResult)} additionally recorded " +
+                            $"for '{FileName}':{result.Value.LineNumber} will be discarded: {newResult}");
+                    }
+                                        
+                    continue;
+                }
                 this.LineResults.Add(result.Value.LineNumber, result.Value);
             }
         }

--- a/src/RunCoverletReport/CoverageResults/Models/LineResult.cs
+++ b/src/RunCoverletReport/CoverageResults/Models/LineResult.cs
@@ -84,5 +84,13 @@ namespace RunCoverletReport.CoverageResults.Models
                 }
             }
         }
+
+        public override string ToString()
+        {
+            var returnValue = $"{nameof(LineNumber)} : {LineNumber}, {nameof(Branch)} : {Branch}, {nameof(Hits)} : {Hits}, " +
+                $"{nameof(HasPartCoverage)} : {HasPartCoverage}, {nameof(Result)} : {Result}, {nameof(ConditionCoverages)} : {ConditionCoverages}, " +
+                $"{nameof(Conditions)} : {(string.Join(",", Conditions))}";
+            return returnValue;
+        }
     }
 }


### PR DESCRIPTION
https://github.com/the-dext/RunCoverletReport/issues/10

 Taking the most optimistic line result in the event there are multiple results for the same line of a class. This can happen when using files from one project in another as linked files.

This prevents the error but probably does not address the root cause well enough. Files that are linked in a project should probably be excluded from being reported on to begin with, so long as they are already being reported on by another project.  I think that would mean substantial changes and definitely a discussion before proceeding with that effort. For now this should at least take the best result possible and prevent the error.

