### PR TITLE
Visual Studio 2022 support

### DIFF
--- a/src/RunCoverletReport.Tests/RunCoverletReport.Tests.csproj
+++ b/src/RunCoverletReport.Tests/RunCoverletReport.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -17,11 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RunCoverletReport/CoverageResults/CoverageReader.cs
+++ b/src/RunCoverletReport/CoverageResults/CoverageReader.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Xml;
     using RunCoverletReport.CoverageResults.Models;
 
@@ -33,7 +34,7 @@
             {
                 var className = classNode.Attributes["name"].Value;
                 var classFileName = classNode.Attributes["filename"].Value;
-                var lineCoverage = classNode.Attributes["line-rate"] == null ? 0 : double.Parse(classNode.Attributes["line-rate"].Value);
+                var lineCoverage = classNode.Attributes["line-rate"] == null ? 0 : double.Parse(classNode.Attributes["line-rate"].Value, CultureInfo.InvariantCulture);
                 var linesNode = classNode.SelectSingleNode("lines");
 
                 var mergeClassResults = classResults.ContainsKey(classFileName);

--- a/src/RunCoverletReport/RunCoverletReport.csproj
+++ b/src/RunCoverletReport/RunCoverletReport.csproj
@@ -96,10 +96,15 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.204" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.5.2047" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Roslynator.Analyzers">
-      <Version>3.0.0</Version>
+      <Version>3.2.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/RunCoverletReport/source.extension.vsixmanifest
+++ b/src/RunCoverletReport/source.extension.vsixmanifest
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="1a4fc182-2715-4040-b982-f76e4c365fbb" Version="1.12.0" Language="en-US" Publisher="Chris Dexter" />
+        <Identity Id="1a4fc182-2715-4040-b982-f76e4c365fbb" Version="1.13.0" Language="en-US" Publisher="Chris Dexter" />
         <DisplayName>Run Coverlet Report</DisplayName>
-        <Description xml:space="preserve">An easy to use visual studio 2019 extension to run coverlet code coverage and then use report generator and show results in visual studio with syntax highlighting.
+        <Description xml:space="preserve">An easy to use visual studio 2022 extension to run coverlet code coverage and then use report generator and show results in visual studio with syntax highlighting.
 
 Note: Relies on Coverlet and Report Generator being available.</Description>
         <MoreInfo>https://github.com/the-dext/RunCoverletReport/blob/master/README.md</MoreInfo>
@@ -14,15 +14,30 @@ Note: Relies on Coverlet and Report Generator being available.</Description>
         <Tags>code coverage, coverlet, unit testing, tdd</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>x86</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,18.0)" DisplayName=" Visual Studio Core Editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
Closing #16 

I updated to .NET 6 and all nuget packages, fixed also some bug with delimeter (, or .)

All tests are passing. 

Please check locally

Below the link to VS 2022 vsix

[RunCoverletReport.vsix.zip](https://github.com/the-dext/RunCoverletReport/files/7574756/RunCoverletReport.vsix.zip)
